### PR TITLE
Fix permission group renaming

### DIFF
--- a/controllers/PermisoController.php
+++ b/controllers/PermisoController.php
@@ -139,7 +139,7 @@ class PermisoController {
                 $permiso = Permiso::obtenerPorNombre($permisoNombreActual);
 
                 if ($permiso) {
-                    Permiso::actualizarNombre($permiso['id'], $permisoNombreNuevo);
+                    Permiso::actualizarNombre($permiso['id'], $permisoNombreNuevo, $grupoNuevo);
                 }
             }
 

--- a/models/permiso.php
+++ b/models/permiso.php
@@ -77,8 +77,13 @@ $conn = Database::getConnection();        if (empty($permisoIds)) return false;
         return $stmt->fetchColumn() > 0;
     }
 
-    public static function actualizarNombre($id, $nuevoNombre) {
-$conn = Database::getConnection();        $stmt = $conn->prepare("UPDATE permiso SET nombre = ? WHERE id = ?");
+    public static function actualizarNombre($id, $nuevoNombre, $nuevoGrupo = null) {
+$conn = Database::getConnection();
+        if ($nuevoGrupo !== null) {
+            $stmt = $conn->prepare("UPDATE permiso SET nombre = ?, grupo = ? WHERE id = ?");
+            return $stmt->execute([$nuevoNombre, $nuevoGrupo, $id]);
+        }
+        $stmt = $conn->prepare("UPDATE permiso SET nombre = ? WHERE id = ?");
         return $stmt->execute([$nuevoNombre, $id]);
     }
 


### PR DESCRIPTION
## Summary
- update `Permiso::actualizarNombre` to optionally change the `grupo` column
- pass the new group to `actualizarNombre` in `PermisoController`

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685474cf8be88326b3864dcd704e2fde